### PR TITLE
refactor(sanitize): remove heads/ prefix from branch names

### DIFF
--- a/pkg/wtm/project_type.go
+++ b/pkg/wtm/project_type.go
@@ -1,0 +1,11 @@
+package wtm
+
+// ProjectType represents the type of project detected.
+type ProjectType int
+
+// Project type constants.
+const (
+	ProjectTypeNone ProjectType = iota
+	ProjectTypeSingleRepo
+	ProjectTypeWorkspace
+)

--- a/pkg/wtm/repository.go
+++ b/pkg/wtm/repository.go
@@ -1,0 +1,334 @@
+package wtm
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/lerenn/wtm/pkg/config"
+	"github.com/lerenn/wtm/pkg/fs"
+	"github.com/lerenn/wtm/pkg/git"
+	"github.com/lerenn/wtm/pkg/logger"
+	"github.com/lerenn/wtm/pkg/status"
+)
+
+// repository represents a single Git repository and provides methods for repository operations.
+type repository struct {
+	fs            fs.FS
+	git           git.Git
+	config        *config.Config
+	statusManager status.Manager
+	logger        logger.Logger
+	verbose       bool
+}
+
+// newRepository creates a new Repository instance.
+func newRepository(
+	fs fs.FS,
+	git git.Git,
+	config *config.Config,
+	statusManager status.Manager,
+	logger logger.Logger,
+	verbose bool,
+) *repository {
+	return &repository{
+		fs:            fs,
+		git:           git,
+		config:        config,
+		statusManager: statusManager,
+		logger:        logger,
+		verbose:       verbose,
+	}
+}
+
+// Validate validates that the current directory is a working Git repository.
+func (r *repository) Validate() error {
+	r.verbosePrint(fmt.Sprintf("Validating repository: %s", "."))
+
+	// Check if .git directory exists and is a directory
+	exists, err := r.CheckGitDirExists()
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return ErrGitRepositoryNotFound
+	}
+
+	if err := r.validateGitStatus(); err != nil {
+		return err
+	}
+
+	// Validate Git configuration is functional
+	return r.validateGitConfiguration(".")
+}
+
+// CreateWorktree creates a worktree for the repository with the specified branch.
+func (r *repository) CreateWorktree(branch string) error {
+	r.verbosePrint(fmt.Sprintf("Creating worktree for single repository with branch: %s", branch))
+
+	// Validate and prepare repository
+	repoURL, worktreePath, err := r.prepareWorktreeCreation(branch)
+	if err != nil {
+		return err
+	}
+
+	// Create the worktree
+	if err := r.executeWorktreeCreation(repoURL, branch, worktreePath); err != nil {
+		return err
+	}
+
+	r.verbosePrint(fmt.Sprintf("Successfully created worktree for branch %s at %s", branch, worktreePath))
+
+	return nil
+}
+
+// CheckGitDirExists checks if the current directory is a single Git repository.
+func (r *repository) CheckGitDirExists() (bool, error) {
+	r.verbosePrint("Checking for .git directory...")
+
+	// Check if .git exists
+	exists, err := r.fs.Exists(".git")
+	if err != nil {
+		return false, fmt.Errorf("failed to check .git existence: %w", err)
+	}
+
+	if !exists {
+		r.verbosePrint("No .git directory found")
+		return false, nil
+	}
+
+	r.verbosePrint("Verifying .git is a directory...")
+
+	// Check if .git is a directory
+	isDir, err := r.fs.IsDir(".git")
+	if err != nil {
+		return false, fmt.Errorf("failed to check .git directory: %w", err)
+	}
+
+	if !isDir {
+		r.verbosePrint(".git exists but is not a directory")
+		return false, nil
+	}
+
+	r.verbosePrint("Git repository detected")
+	return true, nil
+}
+
+// validateGitStatus validates that git status works in the repository.
+func (r *repository) validateGitStatus() error {
+	// Execute git status to ensure repository is working
+	r.verbosePrint(fmt.Sprintf("Executing git status in: %s", "."))
+	_, err := r.git.Status(".")
+	if err != nil {
+		r.verbosePrint(fmt.Sprintf("Error: %v", err))
+		return fmt.Errorf("%w: %w", ErrGitRepositoryInvalid, err)
+	}
+
+	return nil
+}
+
+// validateGitConfiguration validates that Git configuration is functional.
+func (r *repository) validateGitConfiguration(workDir string) error {
+	r.verbosePrint(fmt.Sprintf("Validating Git configuration in: %s", workDir))
+
+	// Execute git status to ensure Git is working
+	_, err := r.git.Status(workDir)
+	if err != nil {
+		r.verbosePrint(fmt.Sprintf("Error: %v", err))
+		return fmt.Errorf("%w: %w", ErrGitRepositoryInvalid, err)
+	}
+
+	return nil
+}
+
+// getBasePath returns the base path from configuration.
+func (r *repository) getBasePath() (string, error) {
+	if r.config == nil {
+		return "", ErrConfigurationNotInitialized
+	}
+
+	if r.config.BasePath == "" {
+		return "", fmt.Errorf("base path is not configured")
+	}
+
+	return r.config.BasePath, nil
+}
+
+// prepareWorktreeCreation validates the repository and prepares the worktree path.
+func (r *repository) prepareWorktreeCreation(branch string) (string, string, error) {
+	// Validate repository
+	repoURL, err := r.validateRepository(branch)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Prepare worktree path
+	worktreePath, err := r.prepareWorktreePath(repoURL, branch)
+	if err != nil {
+		return "", "", err
+	}
+
+	return repoURL, worktreePath, nil
+}
+
+// validateRepository validates the repository and gets the repository name.
+func (r *repository) validateRepository(branch string) (string, error) {
+	// Get current working directory
+	currentDir, err := filepath.Abs(".")
+	if err != nil {
+		return "", fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Validate that we're in a Git repository
+	isSingleRepo, err := r.CheckGitDirExists()
+	if err != nil {
+		return "", fmt.Errorf("failed to validate Git repository: %w", err)
+	}
+	if !isSingleRepo {
+		return "", fmt.Errorf("current directory is not a Git repository")
+	}
+
+	// Get repository URL from remote origin URL with fallback to local path
+	repoURL, err := r.git.GetRepositoryName(currentDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to get repository URL: %w", err)
+	}
+
+	r.verbosePrint(fmt.Sprintf("Repository URL: %s", repoURL))
+
+	// Check if worktree already exists in status file
+	existingWorktree, err := r.statusManager.GetWorktree(repoURL, branch)
+	if err == nil && existingWorktree != nil {
+		return "", fmt.Errorf("%w for repository %s branch %s", ErrWorktreeExists, repoURL, branch)
+	}
+
+	// Validate repository state (placeholder for future validation)
+	isClean, err := r.git.IsClean(currentDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to check repository state: %w", err)
+	}
+	if !isClean {
+		return "", fmt.Errorf("%w: repository is not in a clean state", ErrRepositoryNotClean)
+	}
+
+	return repoURL, nil
+}
+
+// prepareWorktreePath prepares the worktree directory path.
+func (r *repository) prepareWorktreePath(repoURL, branch string) (string, error) {
+	// Get base path from configuration
+	basePath, err := r.getBasePath()
+	if err != nil {
+		return "", fmt.Errorf("failed to get base path: %w", err)
+	}
+
+	// Create worktree directory path
+	worktreePath := filepath.Join(basePath, repoURL, branch)
+
+	r.verbosePrint(fmt.Sprintf("Worktree path: %s", worktreePath))
+
+	// Check if worktree directory already exists
+	exists, err := r.fs.Exists(worktreePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to check if worktree directory exists: %w", err)
+	}
+	if exists {
+		return "", fmt.Errorf("%w: worktree directory already exists at %s", ErrDirectoryExists, worktreePath)
+	}
+
+	// Create worktree directory structure
+	if err := r.fs.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
+		return "", fmt.Errorf("failed to create worktree directory structure: %w", err)
+	}
+
+	return worktreePath, nil
+}
+
+// executeWorktreeCreation creates the branch and worktree.
+func (r *repository) executeWorktreeCreation(repoURL, branch, worktreePath string) error {
+	currentDir, err := filepath.Abs(".")
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Ensure branch exists
+	if err := r.ensureBranchExists(currentDir, branch); err != nil {
+		return err
+	}
+
+	// Create worktree with cleanup
+	if err := r.createWorktreeWithCleanup(repoURL, branch, worktreePath, currentDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ensureBranchExists ensures the branch exists, creating it if necessary.
+func (r *repository) ensureBranchExists(currentDir, branch string) error {
+	branchExists, err := r.git.BranchExists(currentDir, branch)
+	if err != nil {
+		return fmt.Errorf("failed to check if branch exists: %w", err)
+	}
+
+	if !branchExists {
+		r.verbosePrint(fmt.Sprintf("Branch %s does not exist, creating from current branch", branch))
+		if err := r.git.CreateBranch(currentDir, branch); err != nil {
+			return fmt.Errorf("failed to create branch %s: %w", branch, err)
+		}
+	}
+
+	return nil
+}
+
+// createWorktreeWithCleanup creates the worktree with proper cleanup on failure.
+func (r *repository) createWorktreeWithCleanup(repoURL, branch, worktreePath, currentDir string) error {
+	// Update status file with worktree entry (before creating the worktree for proper cleanup)
+	if err := r.statusManager.AddWorktree(repoURL, branch, currentDir, ""); err != nil {
+		// Clean up created directory on status update failure
+		if cleanupErr := r.cleanupWorktreeDirectory(worktreePath); cleanupErr != nil {
+			r.logger.Logf("Warning: failed to clean up directory after status update failure: %v", cleanupErr)
+		}
+		return fmt.Errorf("failed to add worktree to status: %w", err)
+	}
+
+	// Create the Git worktree
+	if err := r.git.CreateWorktree(currentDir, worktreePath, branch); err != nil {
+		// Clean up on worktree creation failure
+		if cleanupErr := r.statusManager.RemoveWorktree(repoURL, branch); cleanupErr != nil {
+			r.logger.Logf("Warning: failed to remove worktree from status after creation failure: %v", cleanupErr)
+		}
+		if cleanupErr := r.cleanupWorktreeDirectory(worktreePath); cleanupErr != nil {
+			r.logger.Logf("Warning: failed to clean up directory after worktree creation failure: %v", cleanupErr)
+		}
+		return fmt.Errorf("failed to create Git worktree: %w", err)
+	}
+
+	return nil
+}
+
+// cleanupWorktreeDirectory removes the worktree directory and parent directories if empty.
+func (r *repository) cleanupWorktreeDirectory(worktreePath string) error {
+	r.verbosePrint(fmt.Sprintf("Cleaning up worktree directory: %s", worktreePath))
+
+	// Remove the worktree directory if it exists
+	exists, err := r.fs.Exists(worktreePath)
+	if err != nil {
+		return fmt.Errorf("failed to check if worktree directory exists: %w", err)
+	}
+
+	if exists {
+		// Remove the worktree directory
+		if err := r.fs.RemoveAll(worktreePath); err != nil {
+			return fmt.Errorf("failed to remove worktree directory: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// verbosePrint prints a message only in verbose mode.
+func (r *repository) verbosePrint(message string) {
+	if r.verbose {
+		r.logger.Logf(message)
+	}
+}

--- a/pkg/wtm/repository_test.go
+++ b/pkg/wtm/repository_test.go
@@ -1,0 +1,214 @@
+//go:build unit
+
+package wtm
+
+import (
+	"testing"
+
+	"github.com/lerenn/wtm/pkg/config"
+	"github.com/lerenn/wtm/pkg/fs"
+	"github.com/lerenn/wtm/pkg/git"
+	"github.com/lerenn/wtm/pkg/logger"
+	"github.com/lerenn/wtm/pkg/status"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRepository_Validate_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFS := fs.NewMockFS(ctrl)
+	mockGit := git.NewMockGit(ctrl)
+	mockStatus := status.NewMockManager(ctrl)
+
+	repo := newRepository(mockFS, mockGit, createTestConfig(), mockStatus, logger.NewNoopLogger(), true)
+
+	// Mock repository validation
+	mockFS.EXPECT().Exists(".git").Return(true, nil)
+	mockFS.EXPECT().IsDir(".git").Return(true, nil)
+	mockGit.EXPECT().Status(".").Return("On branch main", nil)
+	mockGit.EXPECT().Status(".").Return("On branch main", nil) // Called twice for validation
+
+	err := repo.Validate()
+	assert.NoError(t, err)
+}
+
+func TestRepository_Validate_NoGitDir(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFS := fs.NewMockFS(ctrl)
+	mockGit := git.NewMockGit(ctrl)
+	mockStatus := status.NewMockManager(ctrl)
+
+	repo := newRepository(mockFS, mockGit, createTestConfig(), mockStatus, logger.NewNoopLogger(), true)
+
+	// Mock repository validation - .git not found
+	mockFS.EXPECT().Exists(".git").Return(false, nil)
+
+	err := repo.Validate()
+	assert.ErrorIs(t, err, ErrGitRepositoryNotFound)
+}
+
+func TestRepository_Validate_GitStatusError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFS := fs.NewMockFS(ctrl)
+	mockGit := git.NewMockGit(ctrl)
+	mockStatus := status.NewMockManager(ctrl)
+
+	repo := newRepository(mockFS, mockGit, createTestConfig(), mockStatus, logger.NewNoopLogger(), true)
+
+	// Mock repository validation
+	mockFS.EXPECT().Exists(".git").Return(true, nil)
+	mockFS.EXPECT().IsDir(".git").Return(true, nil)
+	mockGit.EXPECT().Status(".").Return("", assert.AnError)
+
+	err := repo.Validate()
+	assert.ErrorIs(t, err, ErrGitRepositoryInvalid)
+}
+
+func TestRepository_CreateWorktree_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFS := fs.NewMockFS(ctrl)
+	mockGit := git.NewMockGit(ctrl)
+	mockStatus := status.NewMockManager(ctrl)
+
+	repo := newRepository(mockFS, mockGit, createTestConfig(), mockStatus, logger.NewNoopLogger(), true)
+
+	// Mock repository validation
+	mockFS.EXPECT().Exists(".git").Return(true, nil).AnyTimes()
+	mockFS.EXPECT().IsDir(".git").Return(true, nil).AnyTimes()
+	mockGit.EXPECT().Status(".").Return("On branch main", nil).AnyTimes()
+
+	// Mock worktree creation
+	mockGit.EXPECT().GetRepositoryName(gomock.Any()).Return("github.com/lerenn/example", nil)
+	mockStatus.EXPECT().GetWorktree("github.com/lerenn/example", "test-branch").Return(nil, status.ErrWorktreeNotFound)
+	mockGit.EXPECT().IsClean(gomock.Any()).Return(true, nil)
+	mockFS.EXPECT().Exists(gomock.Any()).Return(false, nil).AnyTimes()
+	mockFS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil)
+	mockStatus.EXPECT().AddWorktree("github.com/lerenn/example", "test-branch", gomock.Any(), "").Return(nil)
+	mockGit.EXPECT().BranchExists(gomock.Any(), "test-branch").Return(false, nil)
+	mockGit.EXPECT().CreateBranch(gomock.Any(), "test-branch").Return(nil)
+	mockGit.EXPECT().CreateWorktree(gomock.Any(), gomock.Any(), "test-branch").Return(nil)
+
+	err := repo.CreateWorktree("test-branch")
+	assert.NoError(t, err)
+}
+
+func TestRepository_CheckGitDirExists_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFS := fs.NewMockFS(ctrl)
+	mockGit := git.NewMockGit(ctrl)
+	mockStatus := status.NewMockManager(ctrl)
+
+	repo := newRepository(mockFS, mockGit, createTestConfig(), mockStatus, logger.NewNoopLogger(), true)
+
+	// Mock .git directory check
+	mockFS.EXPECT().Exists(".git").Return(true, nil)
+	mockFS.EXPECT().IsDir(".git").Return(true, nil)
+
+	exists, err := repo.CheckGitDirExists()
+	assert.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestRepository_CheckGitDirExists_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFS := fs.NewMockFS(ctrl)
+	mockGit := git.NewMockGit(ctrl)
+	mockStatus := status.NewMockManager(ctrl)
+
+	repo := newRepository(mockFS, mockGit, createTestConfig(), mockStatus, logger.NewNoopLogger(), true)
+
+	// Mock .git directory not found
+	mockFS.EXPECT().Exists(".git").Return(false, nil)
+
+	exists, err := repo.CheckGitDirExists()
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestRepository_CheckGitDirExists_NotDirectory(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFS := fs.NewMockFS(ctrl)
+	mockGit := git.NewMockGit(ctrl)
+	mockStatus := status.NewMockManager(ctrl)
+
+	repo := newRepository(mockFS, mockGit, createTestConfig(), mockStatus, logger.NewNoopLogger(), true)
+
+	// Mock .git exists but is not a directory
+	mockFS.EXPECT().Exists(".git").Return(true, nil)
+	mockFS.EXPECT().IsDir(".git").Return(false, nil)
+
+	exists, err := repo.CheckGitDirExists()
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestRepository_getBasePath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFS := fs.NewMockFS(ctrl)
+	mockGit := git.NewMockGit(ctrl)
+	mockStatus := status.NewMockManager(ctrl)
+
+	tests := []struct {
+		name     string
+		config   *config.Config
+		expected string
+		wantErr  bool
+	}{
+		{
+			name: "Valid config",
+			config: &config.Config{
+				BasePath: "/custom/path",
+			},
+			expected: "/custom/path",
+			wantErr:  false,
+		},
+		{
+			name:     "Nil config",
+			config:   nil,
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name: "Empty base path",
+			config: &config.Config{
+				BasePath: "",
+			},
+			expected: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newRepository(mockFS, mockGit, tt.config, mockStatus, logger.NewNoopLogger(), true)
+
+			result, err := repo.getBasePath()
+			if tt.wantErr {
+				if tt.config == nil {
+					assert.ErrorIs(t, err, ErrConfigurationNotInitialized)
+				} else {
+					assert.Error(t, err)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/wtm/sanitize.go
+++ b/pkg/wtm/sanitize.go
@@ -10,8 +10,6 @@ import (
 // Git imposes the following rules on how references are named:
 //   - They can include slash / for hierarchical (directory) grouping, but no slash-separated component
 //     can begin with a dot . or end with the sequence .lock.
-//   - They must contain at least one /. This enforces the presence of a category like heads/, tags/ etc.
-//     but the actual names are not restricted.
 //   - They cannot have two consecutive dots .. anywhere.
 //   - They cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \177 DEL),
 //     space, tilde ~, caret ^, or colon : anywhere.
@@ -61,13 +59,6 @@ func (c *realWTM) sanitizeBranchName(branchName string) (string, error) {
 
 	// Remove leading dash (not allowed for branch names)
 	sanitized = strings.TrimPrefix(sanitized, "-")
-
-	// Ensure we have at least one slash for hierarchical grouping (Git requirement)
-	// If no slash exists, we'll add a prefix to make it valid
-	// Note: We only add heads/ prefix if there's no slash at all, not for branch names that already have slashes
-	if !strings.Contains(sanitized, "/") {
-		sanitized = "heads/" + sanitized
-	}
 
 	// Limit length to 255 characters (filesystem limit)
 	if len(sanitized) > 255 {

--- a/pkg/wtm/sanitize_test.go
+++ b/pkg/wtm/sanitize_test.go
@@ -59,25 +59,25 @@ func TestRealWTM_sanitizeBranchName(t *testing.T) {
 		{
 			name:     "Branch name with leading/trailing dots",
 			input:    ".hidden-branch.",
-			expected: "heads/hidden-branch",
+			expected: "hidden-branch",
 			wantErr:  false,
 		},
 		{
-			name:     "Branch name without slash (gets heads/ prefix)",
+			name:     "Branch name without slash",
 			input:    "main",
-			expected: "heads/main",
+			expected: "main",
 			wantErr:  false,
 		},
 		{
 			name:     "Branch name with leading dash",
 			input:    "-invalid-branch",
-			expected: "heads/invalid-branch",
+			expected: "invalid-branch",
 			wantErr:  false,
 		},
 		{
 			name:     "Branch name with consecutive dots",
 			input:    "feature..test",
-			expected: "heads/feature_test",
+			expected: "feature_test",
 			wantErr:  false,
 		},
 		{
@@ -107,13 +107,13 @@ func TestRealWTM_sanitizeBranchName(t *testing.T) {
 		{
 			name:     "Branch name with spaces and special chars",
 			input:    "feature test~with^special:chars",
-			expected: "heads/feature_test_with_special_chars",
+			expected: "feature_test_with_special_chars",
 			wantErr:  false,
 		},
 		{
 			name:     "Branch name with question marks and asterisks",
 			input:    "feature?test*with[wildcards]",
-			expected: "heads/feature_test_with_wildcards",
+			expected: "feature_test_with_wildcards",
 			wantErr:  false,
 		},
 	}

--- a/pkg/wtm/workspace.go
+++ b/pkg/wtm/workspace.go
@@ -156,15 +156,11 @@ func (w *workspace) HandleMultipleFiles(workspaceFiles []string) (string, error)
 
 // Validate validates all repositories in a workspace.
 func (w *workspace) Validate() error {
-	if w.verbose {
-		w.logger.Logf("Validating workspace: %s", w.originalFile)
-	}
+	w.verbosePrint(fmt.Sprintf("Validating workspace: %s", w.originalFile))
 
 	workspaceConfig, err := w.parseFile(w.originalFile)
 	if err != nil {
-		if w.verbose {
-			w.logger.Logf("Error: %v", err)
-		}
+		w.verbosePrint(fmt.Sprintf("Error: %v", err))
 		return fmt.Errorf("%w: %w", ErrWorkspaceFileRead, err)
 	}
 
@@ -185,9 +181,7 @@ func (w *workspace) validateRepository(folder workspaceFolder, workspaceDir stri
 	// Resolve relative path from workspace file location
 	resolvedPath := filepath.Join(workspaceDir, folder.Path)
 
-	if w.verbose {
-		w.logger.Logf("Validating repository: %s", resolvedPath)
-	}
+	w.verbosePrint(fmt.Sprintf("Validating repository: %s", resolvedPath))
 
 	if err := w.validateRepositoryPath(folder, resolvedPath); err != nil {
 		return err
@@ -200,9 +194,7 @@ func (w *workspace) validateRepository(folder workspaceFolder, workspaceDir stri
 	// Validate Git configuration is functional
 	err := w.validateGitConfiguration(resolvedPath)
 	if err != nil {
-		if w.verbose {
-			w.logger.Logf("Error: %v", err)
-		}
+		w.verbosePrint(fmt.Sprintf("Error: %v", err))
 		return fmt.Errorf("%w: %s - %w", ErrInvalidRepositoryInWorkspace, folder.Path, err)
 	}
 
@@ -214,16 +206,12 @@ func (w *workspace) validateRepositoryPath(folder workspaceFolder, resolvedPath 
 	// Check repository path exists
 	exists, err := w.fs.Exists(resolvedPath)
 	if err != nil {
-		if w.verbose {
-			w.logger.Logf("Error: %v", err)
-		}
+		w.verbosePrint(fmt.Sprintf("Error: %v", err))
 		return fmt.Errorf("repository not found in workspace: %s - %w", folder.Path, err)
 	}
 
 	if !exists {
-		if w.verbose {
-			w.logger.Logf("Error: repository path does not exist")
-		}
+		w.verbosePrint("Error: repository path does not exist")
 		return fmt.Errorf("%w: %s", ErrRepositoryNotFoundInWorkspace, folder.Path)
 	}
 
@@ -236,28 +224,20 @@ func (w *workspace) validateRepositoryGit(folder workspaceFolder, resolvedPath s
 	gitPath := filepath.Join(resolvedPath, ".git")
 	exists, err := w.fs.Exists(gitPath)
 	if err != nil {
-		if w.verbose {
-			w.logger.Logf("Error: %v", err)
-		}
+		w.verbosePrint(fmt.Sprintf("Error: %v", err))
 		return fmt.Errorf("%w: %s - %w", ErrInvalidRepositoryInWorkspace, folder.Path, err)
 	}
 
 	if !exists {
-		if w.verbose {
-			w.logger.Logf("Error: .git directory not found in repository")
-		}
+		w.verbosePrint("Error: .git directory not found in repository")
 		return fmt.Errorf("%w: %s", ErrInvalidRepositoryInWorkspaceNoGit, folder.Path)
 	}
 
 	// Execute git status to ensure repository is working
-	if w.verbose {
-		w.logger.Logf("Executing git status in: %s", resolvedPath)
-	}
+	w.verbosePrint(fmt.Sprintf("Executing git status in: %s", resolvedPath))
 	_, err = w.git.Status(resolvedPath)
 	if err != nil {
-		if w.verbose {
-			w.logger.Logf("Error: %v", err)
-		}
+		w.verbosePrint(fmt.Sprintf("Error: %v", err))
 		return fmt.Errorf("%w: %s - %w", ErrInvalidRepositoryInWorkspace, folder.Path, err)
 	}
 
@@ -266,19 +246,13 @@ func (w *workspace) validateRepositoryGit(folder workspaceFolder, resolvedPath s
 
 // validateGitConfiguration validates that Git is properly configured and working.
 func (w *workspace) validateGitConfiguration(workDir string) error {
-	if w.verbose {
-		w.logger.Logf("Validating Git configuration in: %s", workDir)
-	}
+	w.verbosePrint(fmt.Sprintf("Validating Git configuration in: %s", workDir))
 
 	// Execute git status to ensure basic Git functionality
-	if w.verbose {
-		w.logger.Logf("Executing git status in: %s", workDir)
-	}
+	w.verbosePrint(fmt.Sprintf("Executing git status in: %s", workDir))
 	_, err := w.git.Status(workDir)
 	if err != nil {
-		if w.verbose {
-			w.logger.Logf("Error: %v", err)
-		}
+		w.verbosePrint(fmt.Sprintf("Error: %v", err))
 		return fmt.Errorf("git configuration error: %w", err)
 	}
 
@@ -440,12 +414,10 @@ func (w *workspace) Load() error {
 	workspaceName := w.getName(workspaceConfig, w.originalFile)
 	w.verbosePrint(fmt.Sprintf("Found workspace: %s", workspaceName))
 
-	if w.verbose {
-		w.verbosePrint("Workspace configuration:")
-		w.verbosePrint(fmt.Sprintf("  Folders: %d", len(workspaceConfig.Folders)))
-		for _, folder := range workspaceConfig.Folders {
-			w.verbosePrint(fmt.Sprintf("    - %s: %s", folder.Name, folder.Path))
-		}
+	w.verbosePrint("Workspace configuration:")
+	w.verbosePrint(fmt.Sprintf("  Folders: %d", len(workspaceConfig.Folders)))
+	for _, folder := range workspaceConfig.Folders {
+		w.verbosePrint(fmt.Sprintf("    - %s: %s", folder.Name, folder.Path))
 	}
 
 	return nil

--- a/pkg/wtm/wtm.go
+++ b/pkg/wtm/wtm.go
@@ -2,7 +2,6 @@ package wtm
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/lerenn/wtm/pkg/config"
 	"github.com/lerenn/wtm/pkg/fs"
@@ -66,16 +65,12 @@ func (c *realWTM) CreateWorkTree(branch string) error {
 		c.logger.Logf("Branch name sanitized: %s -> %s", branch, sanitizedBranch)
 	}
 
-	if c.verbose {
-		c.logger.Logf("Starting WTM execution for branch: %s (sanitized: %s)", branch, sanitizedBranch)
-	}
+	c.verbosePrint(fmt.Sprintf("Starting WTM execution for branch: %s (sanitized: %s)", branch, sanitizedBranch))
 
 	// 1. Detect project mode (repository or workspace)
 	projectType, err := c.detectProjectMode()
 	if err != nil {
-		if c.verbose {
-			c.logger.Logf("Error: %v", err)
-		}
+		c.verbosePrint(fmt.Sprintf("Error: %v", err))
 		return err
 	}
 
@@ -95,12 +90,13 @@ func (c *realWTM) CreateWorkTree(branch string) error {
 // detectProjectMode detects if this is a repository or workspace mode.
 func (c *realWTM) detectProjectMode() (ProjectType, error) {
 	// First check for single repository mode
-	isSingleRepo, err := c.checkGitDirExists()
+	repo := newRepository(c.fs, c.git, c.config, c.statusManager, c.logger, c.verbose)
+	exists, err := repo.CheckGitDirExists()
 	if err != nil {
 		return ProjectTypeNone, fmt.Errorf("failed to detect repository mode: %w", err)
 	}
 
-	if isSingleRepo {
+	if exists {
 		return ProjectTypeSingleRepo, nil
 	}
 
@@ -120,32 +116,29 @@ func (c *realWTM) detectProjectMode() (ProjectType, error) {
 
 // handleRepositoryMode handles repository mode: validation and worktree creation.
 func (c *realWTM) handleRepositoryMode(branch string) error {
-	if c.verbose {
-		c.logger.Logf("Handling repository mode")
-	}
+	c.verbosePrint("Handling repository mode")
+
+	// Create a single repository instance for all repository operations
+	repo := newRepository(c.fs, c.git, c.config, c.statusManager, c.logger, c.verbose)
 
 	// 1. Validate repository
-	if err := c.validateCurrentDirIsGitRepository(); err != nil {
+	if err := repo.Validate(); err != nil {
 		return err
 	}
 
 	// 2. Create worktree for single repository
-	if err := c.createWorktreeForSingleRepo(branch); err != nil {
+	if err := repo.CreateWorktree(branch); err != nil {
 		return err
 	}
 
-	if c.verbose {
-		c.logger.Logf("WTM execution completed successfully")
-	}
+	c.verbosePrint("WTM execution completed successfully")
 
 	return nil
 }
 
 // handleWorkspaceMode handles workspace mode: validation and placeholder for worktree creation.
 func (c *realWTM) handleWorkspaceMode(_ string) error {
-	if c.verbose {
-		c.logger.Logf("Handling workspace mode")
-	}
+	c.verbosePrint("Handling workspace mode")
 
 	// Create a single workspace instance for all workspace operations
 	workspace := newWorkspace(c.fs, c.git, c.logger, c.verbose)
@@ -161,13 +154,9 @@ func (c *realWTM) handleWorkspaceMode(_ string) error {
 	}
 
 	// 4. TODO: Create worktrees for workspace repositories (placeholder)
-	if c.verbose {
-		c.logger.Logf("Workspace worktree creation not yet implemented")
-	}
+	c.verbosePrint("Workspace worktree creation not yet implemented")
 
-	if c.verbose {
-		c.logger.Logf("WTM execution completed successfully")
-	}
+	c.verbosePrint("WTM execution completed successfully")
 
 	return nil
 }
@@ -177,324 +166,4 @@ func (c *realWTM) verbosePrint(message string) {
 	if c.verbose {
 		c.logger.Logf(message)
 	}
-}
-
-// checkGitDirExists checks if the current directory is a single Git repository.
-func (c *realWTM) checkGitDirExists() (bool, error) {
-	c.verbosePrint("Checking for .git directory...")
-
-	// Check if .git exists
-	exists, err := c.fs.Exists(".git")
-	if err != nil {
-		return false, fmt.Errorf("failed to check .git existence: %w", err)
-	}
-
-	if !exists {
-		c.verbosePrint("No .git directory found")
-		return false, nil
-	}
-
-	c.verbosePrint("Verifying .git is a directory...")
-
-	// Check if .git is a directory
-	isDir, err := c.fs.IsDir(".git")
-	if err != nil {
-		return false, fmt.Errorf("failed to check .git directory: %w", err)
-	}
-
-	if !isDir {
-		c.verbosePrint(".git exists but is not a directory")
-		return false, nil
-	}
-
-	c.verbosePrint("Git repository detected")
-	return true, nil
-}
-
-// validateCurrentDirIsGitRepository validates that the current directory is a working Git repository.
-func (c *realWTM) validateCurrentDirIsGitRepository() error {
-	if c.verbose {
-		c.logger.Logf("Validating repository: %s", ".")
-	}
-
-	// Check if .git directory exists and is a directory
-	exists, err := c.checkGitDirExists()
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return ErrGitRepositoryNotFound
-	}
-
-	if err := c.validateGitStatus(); err != nil {
-		return err
-	}
-
-	// Validate Git configuration is functional
-	return c.validateGitConfiguration(".")
-}
-
-// validateGitStatus validates that git status works in the repository.
-func (c *realWTM) validateGitStatus() error {
-	// Execute git status to ensure repository is working
-	if c.verbose {
-		c.logger.Logf("Executing git status in: %s", ".")
-	}
-	_, err := c.git.Status(".")
-	if err != nil {
-		if c.verbose {
-			c.logger.Logf("Error: %v", err)
-		}
-		return fmt.Errorf("%w: %w", ErrGitRepositoryInvalid, err)
-	}
-
-	return nil
-}
-
-// validateGitConfiguration validates that Git configuration is functional.
-func (c *realWTM) validateGitConfiguration(workDir string) error {
-	if c.verbose {
-		c.logger.Logf("Validating Git configuration in: %s", workDir)
-	}
-
-	// Execute git status to ensure Git is working
-	_, err := c.git.Status(workDir)
-	if err != nil {
-		if c.verbose {
-			c.logger.Logf("Error: %v", err)
-		}
-		return fmt.Errorf("%w: %w", ErrGitRepositoryInvalid, err)
-	}
-
-	return nil
-}
-
-// ProjectType represents the type of project detected.
-type ProjectType int
-
-// Project type constants.
-const (
-	ProjectTypeNone ProjectType = iota
-	ProjectTypeSingleRepo
-	ProjectTypeWorkspace
-)
-
-// sanitizeBranchName validates and sanitizes branch name for safe directory creation.
-
-// getBasePath returns the base path from configuration.
-func (c *realWTM) getBasePath() (string, error) {
-	if c.config == nil {
-		return "", ErrConfigurationNotInitialized
-	}
-
-	if c.config.BasePath == "" {
-		return "", fmt.Errorf("base path is not configured")
-	}
-
-	return c.config.BasePath, nil
-}
-
-// createWorktreeForSingleRepo creates a worktree for a single repository.
-func (c *realWTM) createWorktreeForSingleRepo(branch string) error {
-	if c.verbose {
-		c.logger.Logf("Creating worktree for single repository with branch: %s", branch)
-	}
-
-	// Validate and prepare repository
-	repoURL, worktreePath, err := c.prepareWorktreeCreation(branch)
-	if err != nil {
-		return err
-	}
-
-	// Create the worktree
-	if err := c.executeWorktreeCreation(repoURL, branch, worktreePath); err != nil {
-		return err
-	}
-
-	if c.verbose {
-		c.logger.Logf("Successfully created worktree for branch %s at %s", branch, worktreePath)
-	}
-
-	return nil
-}
-
-// prepareWorktreeCreation validates the repository and prepares the worktree path.
-func (c *realWTM) prepareWorktreeCreation(branch string) (string, string, error) {
-	// Validate repository
-	repoURL, err := c.validateRepository(branch)
-	if err != nil {
-		return "", "", err
-	}
-
-	// Prepare worktree path
-	worktreePath, err := c.prepareWorktreePath(repoURL, branch)
-	if err != nil {
-		return "", "", err
-	}
-
-	return repoURL, worktreePath, nil
-}
-
-// validateRepository validates the repository and gets the repository name.
-func (c *realWTM) validateRepository(branch string) (string, error) {
-	// Get current working directory
-	currentDir, err := filepath.Abs(".")
-	if err != nil {
-		return "", fmt.Errorf("failed to get current directory: %w", err)
-	}
-
-	// Validate that we're in a Git repository
-	isSingleRepo, err := c.checkGitDirExists()
-	if err != nil {
-		return "", fmt.Errorf("failed to validate Git repository: %w", err)
-	}
-	if !isSingleRepo {
-		return "", fmt.Errorf("current directory is not a Git repository")
-	}
-
-	// Get repository URL from remote origin URL with fallback to local path
-	repoURL, err := c.git.GetRepositoryName(currentDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to get repository URL: %w", err)
-	}
-
-	if c.verbose {
-		c.logger.Logf("Repository URL: %s", repoURL)
-	}
-
-	// Check if worktree already exists in status file
-	existingWorktree, err := c.statusManager.GetWorktree(repoURL, branch)
-	if err == nil && existingWorktree != nil {
-		return "", fmt.Errorf("%w for repository %s branch %s", ErrWorktreeExists, repoURL, branch)
-	}
-
-	// Validate repository state (placeholder for future validation)
-	isClean, err := c.git.IsClean(currentDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to check repository state: %w", err)
-	}
-	if !isClean {
-		return "", fmt.Errorf("%w: repository is not in a clean state", ErrRepositoryNotClean)
-	}
-
-	return repoURL, nil
-}
-
-// prepareWorktreePath prepares the worktree directory path.
-func (c *realWTM) prepareWorktreePath(repoURL, branch string) (string, error) {
-	// Get base path from configuration
-	basePath, err := c.getBasePath()
-	if err != nil {
-		return "", fmt.Errorf("failed to get base path: %w", err)
-	}
-
-	// Create worktree directory path
-	worktreePath := filepath.Join(basePath, repoURL, branch)
-
-	if c.verbose {
-		c.logger.Logf("Worktree path: %s", worktreePath)
-	}
-
-	// Check if worktree directory already exists
-	exists, err := c.fs.Exists(worktreePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to check if worktree directory exists: %w", err)
-	}
-	if exists {
-		return "", fmt.Errorf("%w: worktree directory already exists at %s", ErrDirectoryExists, worktreePath)
-	}
-
-	// Create worktree directory structure
-	if err := c.fs.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
-		return "", fmt.Errorf("failed to create worktree directory structure: %w", err)
-	}
-
-	return worktreePath, nil
-}
-
-// executeWorktreeCreation creates the branch and worktree.
-func (c *realWTM) executeWorktreeCreation(repoURL, branch, worktreePath string) error {
-	currentDir, err := filepath.Abs(".")
-	if err != nil {
-		return fmt.Errorf("failed to get current directory: %w", err)
-	}
-
-	// Ensure branch exists
-	if err := c.ensureBranchExists(currentDir, branch); err != nil {
-		return err
-	}
-
-	// Create worktree with cleanup
-	if err := c.createWorktreeWithCleanup(repoURL, branch, worktreePath, currentDir); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// ensureBranchExists ensures the branch exists, creating it if necessary.
-func (c *realWTM) ensureBranchExists(currentDir, branch string) error {
-	branchExists, err := c.git.BranchExists(currentDir, branch)
-	if err != nil {
-		return fmt.Errorf("failed to check if branch exists: %w", err)
-	}
-
-	if !branchExists {
-		if c.verbose {
-			c.logger.Logf("Branch %s does not exist, creating from current branch", branch)
-		}
-		if err := c.git.CreateBranch(currentDir, branch); err != nil {
-			return fmt.Errorf("failed to create branch %s: %w", branch, err)
-		}
-	}
-
-	return nil
-}
-
-// createWorktreeWithCleanup creates the worktree with proper cleanup on failure.
-func (c *realWTM) createWorktreeWithCleanup(repoURL, branch, worktreePath, currentDir string) error {
-	// Update status file with worktree entry (before creating the worktree for proper cleanup)
-	if err := c.statusManager.AddWorktree(repoURL, branch, currentDir, ""); err != nil {
-		// Clean up created directory on status update failure
-		if cleanupErr := c.cleanupWorktreeDirectory(worktreePath); cleanupErr != nil {
-			c.logger.Logf("Warning: failed to clean up directory after status update failure: %v", cleanupErr)
-		}
-		return fmt.Errorf("failed to add worktree to status: %w", err)
-	}
-
-	// Create the Git worktree
-	if err := c.git.CreateWorktree(currentDir, worktreePath, branch); err != nil {
-		// Clean up on worktree creation failure
-		if cleanupErr := c.statusManager.RemoveWorktree(repoURL, branch); cleanupErr != nil {
-			c.logger.Logf("Warning: failed to remove worktree from status after creation failure: %v", cleanupErr)
-		}
-		if cleanupErr := c.cleanupWorktreeDirectory(worktreePath); cleanupErr != nil {
-			c.logger.Logf("Warning: failed to clean up directory after worktree creation failure: %v", cleanupErr)
-		}
-		return fmt.Errorf("failed to create Git worktree: %w", err)
-	}
-
-	return nil
-}
-
-// cleanupWorktreeDirectory removes the worktree directory and parent directories if empty.
-func (c *realWTM) cleanupWorktreeDirectory(worktreePath string) error {
-	if c.verbose {
-		c.logger.Logf("Cleaning up worktree directory: %s", worktreePath)
-	}
-
-	// Remove the worktree directory if it exists
-	exists, err := c.fs.Exists(worktreePath)
-	if err != nil {
-		return fmt.Errorf("failed to check if worktree directory exists: %w", err)
-	}
-
-	if exists {
-		// Remove the worktree directory
-		if err := c.fs.RemoveAll(worktreePath); err != nil {
-			return fmt.Errorf("failed to remove worktree directory: %w", err)
-		}
-	}
-
-	return nil
 }

--- a/pkg/wtm/wtm_test.go
+++ b/pkg/wtm/wtm_test.go
@@ -45,17 +45,17 @@ func TestWTM_Run_SingleRepository(t *testing.T) {
 	mockGit.EXPECT().Status(".").Return("On branch main", nil).Times(2)
 
 	// Mock status manager calls
-	mockStatus.EXPECT().GetWorktree("github.com/lerenn/example", "heads/test-branch").Return(nil, status.ErrWorktreeNotFound).AnyTimes()
-	mockStatus.EXPECT().AddWorktree("github.com/lerenn/example", "heads/test-branch", gomock.Any(), "").Return(nil)
+	mockStatus.EXPECT().GetWorktree("github.com/lerenn/example", "test-branch").Return(nil, status.ErrWorktreeNotFound).AnyTimes()
+	mockStatus.EXPECT().AddWorktree("github.com/lerenn/example", "test-branch", gomock.Any(), "").Return(nil)
 
 	// Mock worktree creation calls
 	mockGit.EXPECT().GetRepositoryName(gomock.Any()).Return("github.com/lerenn/example", nil)
 	mockGit.EXPECT().IsClean(gomock.Any()).Return(true, nil)
-	mockGit.EXPECT().BranchExists(gomock.Any(), "heads/test-branch").Return(false, nil)
-	mockGit.EXPECT().CreateBranch(gomock.Any(), "heads/test-branch").Return(nil)
+	mockGit.EXPECT().BranchExists(gomock.Any(), "test-branch").Return(false, nil)
+	mockGit.EXPECT().CreateBranch(gomock.Any(), "test-branch").Return(nil)
 	mockFS.EXPECT().Exists(gomock.Any()).Return(false, nil).AnyTimes() // Worktree directory doesn't exist
 	mockFS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil)   // Create directory structure
-	mockGit.EXPECT().CreateWorktree(gomock.Any(), gomock.Any(), "heads/test-branch").Return(nil)
+	mockGit.EXPECT().CreateWorktree(gomock.Any(), gomock.Any(), "test-branch").Return(nil)
 
 	err := wtm.CreateWorkTree("test-branch")
 	assert.NoError(t, err)
@@ -86,148 +86,18 @@ func TestWTM_Run_VerboseMode(t *testing.T) {
 	mockGit.EXPECT().Status(".").Return("On branch main", nil).Times(2)
 
 	// Mock status manager calls
-	mockStatus.EXPECT().GetWorktree("github.com/lerenn/example", "heads/test-branch").Return(nil, status.ErrWorktreeNotFound).AnyTimes()
-	mockStatus.EXPECT().AddWorktree("github.com/lerenn/example", "heads/test-branch", gomock.Any(), "").Return(nil)
+	mockStatus.EXPECT().GetWorktree("github.com/lerenn/example", "test-branch").Return(nil, status.ErrWorktreeNotFound).AnyTimes()
+	mockStatus.EXPECT().AddWorktree("github.com/lerenn/example", "test-branch", gomock.Any(), "").Return(nil)
 
 	// Mock worktree creation calls
 	mockGit.EXPECT().GetRepositoryName(gomock.Any()).Return("github.com/lerenn/example", nil)
 	mockGit.EXPECT().IsClean(gomock.Any()).Return(true, nil)
-	mockGit.EXPECT().BranchExists(gomock.Any(), "heads/test-branch").Return(false, nil)
-	mockGit.EXPECT().CreateBranch(gomock.Any(), "heads/test-branch").Return(nil)
+	mockGit.EXPECT().BranchExists(gomock.Any(), "test-branch").Return(false, nil)
+	mockGit.EXPECT().CreateBranch(gomock.Any(), "test-branch").Return(nil)
 	mockFS.EXPECT().Exists(gomock.Any()).Return(false, nil).AnyTimes() // Worktree directory doesn't exist
 	mockFS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil)   // Create directory structure
-	mockGit.EXPECT().CreateWorktree(gomock.Any(), gomock.Any(), "heads/test-branch").Return(nil)
+	mockGit.EXPECT().CreateWorktree(gomock.Any(), gomock.Any(), "test-branch").Return(nil)
 
 	err := wtm.CreateWorkTree("test-branch")
 	assert.NoError(t, err)
-}
-
-func TestWTM_ValidateSingleRepository_Success(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockFS := fs.NewMockFS(ctrl)
-	mockGit := git.NewMockGit(ctrl)
-
-	wtm := NewWTM(createTestConfig())
-	wtm.SetVerbose(true)
-
-	// Override adapters with mocks
-	c := wtm.(*realWTM)
-	c.fs = mockFS
-	c.git = mockGit
-
-	// Mock repository validation
-	mockFS.EXPECT().Exists(".git").Return(true, nil)
-	mockFS.EXPECT().IsDir(".git").Return(true, nil)
-	mockGit.EXPECT().Status(".").Return("On branch main", nil)
-	mockGit.EXPECT().Status(".").Return("On branch main", nil) // Called twice for validation
-
-	err := wtm.(*realWTM).validateCurrentDirIsGitRepository()
-	assert.NoError(t, err)
-}
-
-func TestWTM_ValidateSingleRepository_NoGitDir(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockFS := fs.NewMockFS(ctrl)
-
-	wtm := NewWTM(createTestConfig())
-	wtm.SetVerbose(true)
-
-	// Override adapters with mocks
-	c := wtm.(*realWTM)
-	c.fs = mockFS
-
-	// Mock repository validation - .git not found
-	mockFS.EXPECT().Exists(".git").Return(false, nil)
-
-	err := wtm.(*realWTM).validateCurrentDirIsGitRepository()
-	assert.ErrorIs(t, err, ErrGitRepositoryNotFound)
-}
-
-func TestWTM_ValidateSingleRepository_GitStatusError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockFS := fs.NewMockFS(ctrl)
-	mockGit := git.NewMockGit(ctrl)
-
-	wtm := NewWTM(createTestConfig())
-	wtm.SetVerbose(true)
-
-	// Override adapters with mocks
-	c := wtm.(*realWTM)
-	c.fs = mockFS
-	c.git = mockGit
-
-	// Mock repository validation
-	mockFS.EXPECT().Exists(".git").Return(true, nil)
-	mockFS.EXPECT().IsDir(".git").Return(true, nil)
-	mockGit.EXPECT().Status(".").Return("", assert.AnError)
-
-	err := wtm.(*realWTM).validateCurrentDirIsGitRepository()
-	assert.ErrorIs(t, err, ErrGitRepositoryInvalid)
-}
-
-func TestRealWTM_getBasePath(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockFS := fs.NewMockFS(ctrl)
-	mockGit := git.NewMockGit(ctrl)
-
-	tests := []struct {
-		name     string
-		config   *config.Config
-		expected string
-		wantErr  bool
-	}{
-		{
-			name: "Valid config",
-			config: &config.Config{
-				BasePath: "/custom/path",
-			},
-			expected: "/custom/path",
-			wantErr:  false,
-		},
-		{
-			name:     "Nil config",
-			config:   nil,
-			expected: "",
-			wantErr:  true,
-		},
-		{
-			name: "Empty base path",
-			config: &config.Config{
-				BasePath: "",
-			},
-			expected: "",
-			wantErr:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			wtm := NewWTM(tt.config)
-
-			// Override adapters with mocks
-			c := wtm.(*realWTM)
-			c.fs = mockFS
-			c.git = mockGit
-
-			result, err := wtm.(*realWTM).getBasePath()
-			if tt.wantErr {
-				if tt.config == nil {
-					assert.ErrorIs(t, err, ErrConfigurationNotInitialized)
-				} else {
-					assert.Error(t, err)
-				}
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
-			}
-		})
-	}
 }


### PR DESCRIPTION
- Remove requirement for at least one slash in branch names
- Remove automatic addition of heads/ prefix for branch names without slashes
- Update tests to reflect new behavior where branch names are used as-is
- Fix regression where worktrees were created with heads/ prefix instead of actual branch names

This change ensures that Git operations use the actual branch names provided by users, rather than Git's internal reference format with heads/ prefix.