### PR TITLE
fix(wtm): store original repository path instead of worktree path in status file

### DIFF
--- a/pkg/wtm/repository.go
+++ b/pkg/wtm/repository.go
@@ -319,7 +319,8 @@ func (r *repository) ensureBranchExists(currentDir, branch string) error {
 // createWorktreeWithCleanup creates the worktree with proper cleanup on failure.
 func (r *repository) createWorktreeWithCleanup(repoURL, branch, worktreePath, currentDir string) error {
 	// Update status file with worktree entry (before creating the worktree for proper cleanup)
-	if err := r.statusManager.AddWorktree(repoURL, branch, worktreePath, ""); err != nil {
+	// Store the original repository path, not the worktree path
+	if err := r.statusManager.AddWorktree(repoURL, branch, currentDir, ""); err != nil {
 		// Clean up created directory on status update failure
 		if cleanupErr := r.cleanupWorktreeDirectory(worktreePath); cleanupErr != nil {
 			r.logger.Logf("Warning: failed to clean up directory after status update failure: %v", cleanupErr)

--- a/pkg/wtm/wtm.go
+++ b/pkg/wtm/wtm.go
@@ -2,6 +2,7 @@ package wtm
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/lerenn/wtm/pkg/config"
 	"github.com/lerenn/wtm/pkg/fs"
@@ -287,14 +288,17 @@ func (c *realWTM) OpenWorktree(worktreeName, ideName string) error {
 		return fmt.Errorf("failed to get repository URL: %w", err)
 	}
 
-	// Get worktree from status.yaml using repository URL and branch name
-	worktree, err := c.statusManager.GetWorktree(repoURL, worktreeName)
+	// Get worktree from status.yaml using repository URL and branch name to verify it exists
+	_, err = c.statusManager.GetWorktree(repoURL, worktreeName)
 	if err != nil {
 		return fmt.Errorf("%w: %s", ide.ErrWorktreeNotFound, worktreeName)
 	}
 
-	// Open IDE with the worktree path
-	if err := c.ideManager.OpenIDE(ideName, worktree.Path, c.verbose); err != nil {
+	// Derive worktree path from original repository path and branch name
+	worktreePath := filepath.Join(c.config.BasePath, repoURL, worktreeName)
+
+	// Open IDE with the derived worktree path
+	if err := c.ideManager.OpenIDE(ideName, worktreePath, c.verbose); err != nil {
 		return err
 	}
 

--- a/pkg/wtm/wtm_test.go
+++ b/pkg/wtm/wtm_test.go
@@ -149,8 +149,8 @@ func TestWTM_OpenWorktree(t *testing.T) {
 	}
 	mockStatus.EXPECT().GetWorktree("github.com/lerenn/example", "test-branch").Return(worktree, nil)
 
-	// Mock IDE opening
-	mockIDE.EXPECT().OpenIDE("cursor", "/path/to/worktree", false).Return(nil)
+	// Mock IDE opening - now uses derived worktree path
+	mockIDE.EXPECT().OpenIDE("cursor", "/test/base/path/github.com/lerenn/example/test-branch", false).Return(nil)
 
 	err := wtm.OpenWorktree("test-branch", "cursor")
 	assert.NoError(t, err)

--- a/test/create_repo_test.go
+++ b/test/create_repo_test.go
@@ -221,10 +221,13 @@ func TestCreateWorktreeWithIDE(t *testing.T) {
 	require.NotNil(t, status.Repositories, "Status file should have repositories section")
 	require.Len(t, status.Repositories, 1, "Should have one repository entry")
 
-	// Verify that the worktree path in status.yaml is correct (not the original repo path)
+	// Verify that the original repository path in status.yaml is correct (not the worktree path)
 	worktreeEntry := status.Repositories[0]
-	expectedPath := filepath.Join(setup.WtmPath, "repo", "feature", "test-ide")
-	assert.Equal(t, expectedPath, worktreeEntry.Path, "Worktree path should be the worktree directory, not the original repository")
+	expectedPath, err := filepath.EvalSymlinks(setup.RepoPath)
+	require.NoError(t, err)
+	actualPath, err := filepath.EvalSymlinks(worktreeEntry.Path)
+	require.NoError(t, err)
+	assert.Equal(t, expectedPath, actualPath, "Path should be the original repository directory, not the worktree directory")
 }
 
 // TestCreateWorktreeWithUnsupportedIDE tests creating a worktree with unsupported IDE

--- a/test/list_repo_test.go
+++ b/test/list_repo_test.go
@@ -113,7 +113,11 @@ func TestListWorktreesWithWorktrees(t *testing.T) {
 		branchNames[i] = wt.Branch
 		assert.NotEmpty(t, wt.URL, "Repository URL should be set")
 		assert.NotEmpty(t, wt.Path, "Repository path should be set")
-		assert.Contains(t, wt.Path, setup.WtmPath, "Worktree path should be in .wtm directory")
+		expectedPath, err := filepath.EvalSymlinks(setup.RepoPath)
+		require.NoError(t, err)
+		actualPath, err := filepath.EvalSymlinks(wt.Path)
+		require.NoError(t, err)
+		assert.Equal(t, expectedPath, actualPath, "Path should be the original repository directory")
 	}
 
 	// Check that both expected branches are present

--- a/test/open_repo_test.go
+++ b/test/open_repo_test.go
@@ -41,14 +41,17 @@ func TestOpenExistingWorktree(t *testing.T) {
 	err = wtmInstance.OpenWorktree("feature/existing-ide", "dummy")
 	require.NoError(t, err, "Opening worktree with IDE should succeed")
 
-	// Verify that the worktree path in status.yaml is correct (not the original repo path)
+	// Verify that the original repository path in status.yaml is correct (not the worktree path)
 	status := readStatusFile(t, setup.StatusPath)
 	require.NotNil(t, status.Repositories, "Status file should have repositories section")
 	require.Len(t, status.Repositories, 1, "Should have one repository entry")
 
 	worktreeEntry := status.Repositories[0]
-	expectedPath := filepath.Join(setup.WtmPath, "repo", "feature", "existing-ide")
-	assert.Equal(t, expectedPath, worktreeEntry.Path, "Worktree path should be the worktree directory, not the original repository")
+	expectedPath, err := filepath.EvalSymlinks(setup.RepoPath)
+	require.NoError(t, err)
+	actualPath, err := filepath.EvalSymlinks(worktreeEntry.Path)
+	require.NoError(t, err)
+	assert.Equal(t, expectedPath, actualPath, "Path should be the original repository directory, not the worktree directory")
 }
 
 // TestOpenNonExistentWorktree tests opening a non-existent worktree


### PR DESCRIPTION
- Modified repository.go to store original repository path in status file
- Updated wtm.go to derive worktree path from original path and branch name
- Updated all tests to expect original repository path
- Fixed IDE opening functionality to use derived worktree path
- Resolves issue where status file incorrectly stored worktree paths